### PR TITLE
fix: team gathering dialog

### DIFF
--- a/web/src/pages/games/game_id/_blocks/team-gathering-dialog.tsx
+++ b/web/src/pages/games/game_id/_blocks/team-gathering-dialog.tsx
@@ -44,9 +44,14 @@ function TeamGatheringDialog(props: TeamGatheringDialogProps) {
   const [tab, setTab] = useState<Tab>("create");
 
   const createFormSchema = z.object({
-    name: z.string({
-      message: t("team:form.name.required"),
-    }),
+    name: z
+      .string({
+        message: t("team:form.name.required"),
+      })
+      .trim()
+      .min(1, {
+        message: t("team:form.name.required"),
+      }),
   });
 
   const createForm = useForm<z.infer<typeof createFormSchema>>({

--- a/web/src/pages/games/game_id/_blocks/team-gathering-dialog.tsx
+++ b/web/src/pages/games/game_id/_blocks/team-gathering-dialog.tsx
@@ -215,7 +215,7 @@ function TeamGatheringDialog(props: TeamGatheringDialogProps) {
             </div>
 
             {/* Form */}
-            <Form {...createForm}>
+            <Form key="create" {...createForm}>
               <form
                 onSubmit={createForm.handleSubmit(onCreateFormSubmit)}
                 autoComplete="off"
@@ -301,7 +301,7 @@ function TeamGatheringDialog(props: TeamGatheringDialogProps) {
             </div>
 
             {/* Form */}
-            <Form {...joinForm}>
+            <Form key="join" {...joinForm}>
               <form
                 onSubmit={joinForm.handleSubmit(onJoinFormSubmit)}
                 autoComplete="off"


### PR DESCRIPTION
- Reject empty team names on creation; a blank name previously passed validation.
- Fix the invite code field being uneditable after switching to the join tab, caused by the two tabs sharing a reused form instance.